### PR TITLE
Update unico_check to v4.53.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
 
-  unico_check: 4.52.0
+  unico_check: 4.53.0
   cupertino_icons: ^1.0.2
   get: ^4.6.5
 


### PR DESCRIPTION

    Automatic update of `unico_check` to version **4.53.0**.
    
    📅 **Release date:** 21/05/2026
    🔗 **Changelog:** https://pub.dev/packages/unico_check/changelog

    ---
    
    ### Release Notes
    - Atualização da sdk nativa Android
para 6.5.0 release notes
- Atualização da sdk nativa iOS
para 3.0.0 release notes
- Versão mínima do iOS: O suporte ao iOS 12 foi encerrado. A versão mínima suportada passa a ser o iOS 13.
    